### PR TITLE
Various updates to AutoTable & BaseTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.0
+
+- Add `fullWidth` prop to AutoTable/BaseTable
+- Add `options` prop to AutoTable for Data
+- Rename AutoTable's `filter` => `variables`
+
 ## 0.10.0
 
 - Add default UI for a noResults state

--- a/lib/AutoTable.js
+++ b/lib/AutoTable.js
@@ -179,6 +179,7 @@ var AutoTable = function (_React$Component) {
       var _props = this.props,
           action = _props.action,
           headerPadding = _props.headerPadding,
+          options = _props.options,
           pageable = _props.pageable,
           searchable = _props.searchable,
           sortable = _props.sortable,
@@ -237,7 +238,7 @@ var AutoTable = function (_React$Component) {
 
       return _react2.default.createElement(
         _perchData.Data,
-        { action: action, variables: dataVariables },
+        { action: action, options: options, variables: dataVariables },
         function (result) {
           return _react2.default.createElement(
             _2.BaseTable,
@@ -410,9 +411,11 @@ AutoTable.propTypes = {
     label: _propTypes2.default.string,
     sortId: _propTypes2.default.string
   })])).isRequired,
-  variables: _propTypes2.default.object, // eslint-disable-line react/forbid-prop-types
   headerPadding: _propTypes2.default.string,
   initialOrdering: _propTypes2.default.string,
+  multiselectable: _propTypes2.default.bool,
+  multiselectActions: _propTypes2.default.arrayOf(_propTypes2.default.shape(_ActionButton.ActionButtonPropTypes)),
+  options: _propTypes2.default.object, // eslint-disable-line react/forbid-prop-types
   pageable: _propTypes2.default.bool,
   renderError: _propTypes2.default.func,
   renderNoResults: _propTypes2.default.func,
@@ -420,12 +423,10 @@ AutoTable.propTypes = {
   rowsPerPageOptions: _propTypes2.default.arrayOf(_propTypes2.default.number),
   searchable: _propTypes2.default.bool,
   sortable: _propTypes2.default.bool,
-  multiselectable: _propTypes2.default.bool,
-  multiselectActions: _propTypes2.default.arrayOf(_propTypes2.default.shape(_ActionButton.ActionButtonPropTypes))
+  variables: _propTypes2.default.object // eslint-disable-line react/forbid-prop-types
 };
 
 AutoTable.defaultProps = {
-  variables: null,
   headerPadding: "default",
   pageable: false,
   renderError: null,
@@ -436,7 +437,9 @@ AutoTable.defaultProps = {
   initialOrdering: null,
   sortable: false,
   multiselectable: false,
-  multiselectActions: []
+  multiselectActions: [],
+  options: null,
+  variables: null
 };
 
 (0, _reactLifecyclesCompat.polyfill)(AutoTable);

--- a/lib/AutoTable.js
+++ b/lib/AutoTable.js
@@ -178,6 +178,7 @@ var AutoTable = function (_React$Component) {
 
       var _props = this.props,
           action = _props.action,
+          fullWidth = _props.fullWidth,
           headerPadding = _props.headerPadding,
           options = _props.options,
           pageable = _props.pageable,
@@ -250,6 +251,7 @@ var AutoTable = function (_React$Component) {
 
                 return column;
               }),
+              fullWidth: fullWidth,
               headerPadding: headerPadding,
               onSearch: _this2.handleSearch,
               onSort: _this2.handleSort,
@@ -411,6 +413,7 @@ AutoTable.propTypes = {
     label: _propTypes2.default.string,
     sortId: _propTypes2.default.string
   })])).isRequired,
+  fullWidth: _propTypes2.default.bool,
   headerPadding: _propTypes2.default.string,
   initialOrdering: _propTypes2.default.string,
   multiselectable: _propTypes2.default.bool,
@@ -427,6 +430,7 @@ AutoTable.propTypes = {
 };
 
 AutoTable.defaultProps = {
+  fullWidth: false,
   headerPadding: "default",
   pageable: false,
   renderError: null,

--- a/lib/AutoTable.js
+++ b/lib/AutoTable.js
@@ -103,14 +103,14 @@ var AutoTable = function (_React$Component) {
   _createClass(AutoTable, null, [{
     key: "getDerivedStateFromProps",
     value: function getDerivedStateFromProps(nextProps, prevState) {
-      if (!(0, _lodash2.default)(nextProps.filter, prevState.filter)) {
+      if (!(0, _lodash2.default)(nextProps.variables, prevState.variables)) {
         var _getSortFromOrdering = getSortFromOrdering(nextProps.initialOrdering),
             sortColumn = _getSortFromOrdering.sortColumn,
             sortDirection = _getSortFromOrdering.sortDirection;
 
         return {
           allItems: new Set(),
-          filter: nextProps.filter,
+          variables: nextProps.variables,
           page: 1,
           sortColumn: sortColumn,
           sortDirection: sortDirection,
@@ -128,9 +128,9 @@ var AutoTable = function (_React$Component) {
 
     _initialiseProps.call(_this);
 
-    var filter = props.filter,
-        initialOrdering = props.initialOrdering,
-        rowsPerPage = props.rowsPerPage;
+    var initialOrdering = props.initialOrdering,
+        rowsPerPage = props.rowsPerPage,
+        variables = props.variables;
 
     var _getSortFromOrdering2 = getSortFromOrdering(initialOrdering),
         sortColumn = _getSortFromOrdering2.sortColumn,
@@ -138,14 +138,14 @@ var AutoTable = function (_React$Component) {
 
     _this.state = {
       allItems: new Set(),
-      filter: filter,
       ordering: initialOrdering,
       page: 1,
       rowsPerPage: rowsPerPage,
       search: null,
       sortColumn: sortColumn,
       sortDirection: sortDirection,
-      selectedItems: new Set()
+      selectedItems: new Set(),
+      variables: variables
     };
     return _this;
   }
@@ -186,7 +186,7 @@ var AutoTable = function (_React$Component) {
           multiselectActions = _props.multiselectActions,
           columns = _props.columns;
       var _state2 = this.state,
-          filter = _state2.filter,
+          variables = _state2.variables,
           ordering = _state2.ordering,
           page = _state2.page,
           rowsPerPage = _state2.rowsPerPage,
@@ -219,7 +219,7 @@ var AutoTable = function (_React$Component) {
         });
       }
 
-      var variables = _extends({}, filter, { ordering: ordering, page: page, rowsPerPage: rowsPerPage, search: search });
+      var dataVariables = _extends({}, variables, { ordering: ordering, page: page, rowsPerPage: rowsPerPage, search: search });
 
       var tableActions = multiselectActions.map(function (_ref3) {
         var _onClick = _ref3.onClick,
@@ -237,7 +237,7 @@ var AutoTable = function (_React$Component) {
 
       return _react2.default.createElement(
         _perchData.Data,
-        { action: action, variables: variables },
+        { action: action, variables: dataVariables },
         function (result) {
           return _react2.default.createElement(
             _2.BaseTable,
@@ -260,7 +260,7 @@ var AutoTable = function (_React$Component) {
             },
             _this2.getTableBodyForResult(result, {
               columns: columnsWithoutCheckbox,
-              variables: variables
+              dataVariables: dataVariables
             })
           );
         }
@@ -312,7 +312,6 @@ var _initialiseProps = function _initialiseProps() {
         selectedItems = _state4.selectedItems;
 
     var numColumns = multiselectable ? columns.length + 1 : columns.length;
-
     if (error) {
       return renderError ? renderError(error, { columns: columns, data: data, refetch: refetch, variables: variables }) : _react2.default.createElement(ErrorRow, { columnCount: numColumns });
     } else if (loading) {
@@ -324,12 +323,17 @@ var _initialiseProps = function _initialiseProps() {
       return renderNoResults ? renderNoResults(null, { columns: columns, data: data, refetch: refetch, variables: variables }) : _react2.default.createElement(NoResultsRow, { columnCount: numColumns });
     } else if (data) {
       _this3.setState({ allItems: new Set(data.results) });
-
-      return data.results.map(function (item) {
-        var cells = children(item, { columns: columns, data: data, refetch: refetch, variables: variables });
+      return data.results.map(function (item, index) {
+        var cells = children(item, {
+          columns: columns,
+          data: data,
+          index: index,
+          refetch: refetch,
+          variables: variables
+        });
         return _react2.default.createElement(
           _materialUi.TableRow,
-          { hover: true, key: item.id || JSON.stringify(item) },
+          { hover: true, key: item.id },
           multiselectable && _react2.default.createElement(
             _materialUi.TableCell,
             { padding: "checkbox" },
@@ -406,7 +410,7 @@ AutoTable.propTypes = {
     label: _propTypes2.default.string,
     sortId: _propTypes2.default.string
   })])).isRequired,
-  filter: _propTypes2.default.object, // eslint-disable-line react/forbid-prop-types
+  variables: _propTypes2.default.object, // eslint-disable-line react/forbid-prop-types
   headerPadding: _propTypes2.default.string,
   initialOrdering: _propTypes2.default.string,
   pageable: _propTypes2.default.bool,
@@ -421,7 +425,7 @@ AutoTable.propTypes = {
 };
 
 AutoTable.defaultProps = {
-  filter: null,
+  variables: null,
   headerPadding: "default",
   pageable: false,
   renderError: null,

--- a/lib/BaseTable.js
+++ b/lib/BaseTable.js
@@ -36,6 +36,9 @@ var toggleSort = function toggleSort(column, prevColumn, prevDirection) {
 
 var styles = function styles() {
   return {
+    fullWidthContainer: {
+      width: "100%"
+    },
     headerCell: {
       whiteSpace: "nowrap",
       textTransform: "uppercase"
@@ -132,6 +135,7 @@ var BaseTable = function BaseTable(_ref3) {
       children = _ref3.children,
       classes = _ref3.classes,
       columns = _ref3.columns,
+      fullWidth = _ref3.fullWidth,
       headerPadding = _ref3.headerPadding,
       onSearch = _ref3.onSearch,
       onSort = _ref3.onSort,
@@ -142,7 +146,7 @@ var BaseTable = function BaseTable(_ref3) {
       sortDirection = _ref3.sortDirection;
   return _react2.default.createElement(
     "div",
-    null,
+    { className: fullWidth ? classes.fullWidthContainer : undefined },
     (searchable || actions) && _react2.default.createElement(
       "div",
       { className: classes.topBar },
@@ -246,6 +250,7 @@ BaseTable.propTypes = {
     label: _propTypes2.default.node,
     sortId: _propTypes2.default.string
   })])).isRequired,
+  fullWidth: _propTypes2.default.bool,
   headerPadding: _propTypes2.default.string,
   onSearch: _propTypes2.default.func,
   onSort: _propTypes2.default.func,
@@ -266,6 +271,7 @@ BaseTable.propTypes = {
 BaseTable.defaultProps = {
   actions: null,
   children: [],
+  fullWidth: false,
   headerPadding: "default",
   onSearch: null,
   onSort: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "perch-components",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perch-components",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "React components for cross-application use at Perch Security",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AutoTable.jsx
+++ b/src/AutoTable.jsx
@@ -222,6 +222,7 @@ class AutoTable extends React.Component {
   render() {
     const {
       action,
+      fullWidth,
       headerPadding,
       options,
       pageable,
@@ -295,6 +296,7 @@ class AutoTable extends React.Component {
                 ? tableColumns
                 : tableColumns.map(({ sortId, ...column }) => column)
             }
+            fullWidth={fullWidth}
             headerPadding={headerPadding}
             onSearch={this.handleSearch}
             onSort={this.handleSort}
@@ -329,6 +331,7 @@ AutoTable.propTypes = {
       })
     ])
   ).isRequired,
+  fullWidth: PropTypes.bool,
   headerPadding: PropTypes.string,
   initialOrdering: PropTypes.string,
   multiselectable: PropTypes.bool,
@@ -345,6 +348,7 @@ AutoTable.propTypes = {
 };
 
 AutoTable.defaultProps = {
+  fullWidth: false,
   headerPadding: "default",
   pageable: false,
   renderError: null,

--- a/src/AutoTable.jsx
+++ b/src/AutoTable.jsx
@@ -223,6 +223,7 @@ class AutoTable extends React.Component {
     const {
       action,
       headerPadding,
+      options,
       pageable,
       searchable,
       sortable,
@@ -285,7 +286,7 @@ class AutoTable extends React.Component {
       : tableColumns;
 
     return (
-      <Data action={action} variables={dataVariables}>
+      <Data action={action} options={options} variables={dataVariables}>
         {result => (
           <Table
             actions={tableActions}
@@ -332,6 +333,7 @@ AutoTable.propTypes = {
   initialOrdering: PropTypes.string,
   multiselectable: PropTypes.bool,
   multiselectActions: PropTypes.arrayOf(PropTypes.shape(ActionButtonPropTypes)),
+  options: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   pageable: PropTypes.bool,
   renderError: PropTypes.func,
   renderNoResults: PropTypes.func,
@@ -354,6 +356,7 @@ AutoTable.defaultProps = {
   sortable: false,
   multiselectable: false,
   multiselectActions: [],
+  options: null,
   variables: null
 };
 

--- a/src/BaseTable.jsx
+++ b/src/BaseTable.jsx
@@ -20,6 +20,9 @@ const toggleSort = (column, prevColumn, prevDirection) =>
   column === prevColumn ? toggleDirection(prevDirection) : "asc";
 
 const styles = () => ({
+  fullWidthContainer: {
+    width: "100%"
+  },
   headerCell: {
     whiteSpace: "nowrap",
     textTransform: "uppercase"
@@ -103,6 +106,7 @@ const BaseTable = ({
   children,
   classes,
   columns,
+  fullWidth,
   headerPadding,
   onSearch,
   onSort,
@@ -112,7 +116,7 @@ const BaseTable = ({
   sortColumn,
   sortDirection
 }) => (
-  <div>
+  <div className={fullWidth ? classes.fullWidthContainer: undefined}>
     {(searchable || actions) && (
       <div className={classes.topBar}>
         {searchable && (
@@ -215,6 +219,7 @@ BaseTable.propTypes = {
       })
     ])
   ).isRequired,
+  fullWidth: PropTypes.bool,
   headerPadding: PropTypes.string,
   onSearch: PropTypes.func,
   onSort: PropTypes.func,
@@ -235,6 +240,7 @@ BaseTable.propTypes = {
 BaseTable.defaultProps = {
   actions: null,
   children: [],
+  fullWidth: false,
   headerPadding: "default",
   onSearch: null,
   onSort: null,

--- a/src/BaseTable.jsx
+++ b/src/BaseTable.jsx
@@ -116,7 +116,7 @@ const BaseTable = ({
   sortColumn,
   sortDirection
 }) => (
-  <div className={fullWidth ? classes.fullWidthContainer: undefined}>
+  <div className={fullWidth ? classes.fullWidthContainer : undefined}>
     {(searchable || actions) && (
       <div className={classes.topBar}>
         {searchable && (


### PR DESCRIPTION
Initially these changes were going to be specific to passing caching options to the Data component but after talking with @cvburgess I made some additional changes.

- Renamed AutoTable `filter` prop to `variables`
- Updated AutoTable to accept and pass options for Data component
- Added fullWidth prop to Base/Autotable

@cvburgess The renaming of the `filter` prop will be a breaking change, do you want me to bump the version or do you usually do that before release?