### PR TITLE
fix(autotable): pass through correct variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.12.0
+
+- Fix inccorect variables being passed within AutoTable
+
 ## 0.11.0
 
 - Add `fullWidth` prop to AutoTable/BaseTable

--- a/lib/AutoTable.js
+++ b/lib/AutoTable.js
@@ -230,7 +230,7 @@ var AutoTable = function (_React$Component) {
         return _extends({}, props, {
           onClick: function onClick() {
             _this2.setState({ selectedItems: new Set() });
-            return _onClick([].concat(_toConsumableArray(selectedItems)), { variables: variables });
+            return _onClick([].concat(_toConsumableArray(selectedItems)), { variables: dataVariables });
           }
         });
       });
@@ -263,7 +263,7 @@ var AutoTable = function (_React$Component) {
             },
             _this2.getTableBodyForResult(result, {
               columns: columnsWithoutCheckbox,
-              dataVariables: dataVariables
+              variables: dataVariables
             })
           );
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perch-components",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "React components for cross-application use at Perch Security",
   "main": "lib/index.js",
   "scripts": {

--- a/src/AutoTable.jsx
+++ b/src/AutoTable.jsx
@@ -278,7 +278,7 @@ class AutoTable extends React.Component {
       ...props,
       onClick: () => {
         this.setState({ selectedItems: new Set() });
-        return onClick([...selectedItems], { variables });
+        return onClick([...selectedItems], { variables: dataVariables });
       }
     }));
 
@@ -310,7 +310,7 @@ class AutoTable extends React.Component {
           >
             {this.getTableBodyForResult(result, {
               columns: columnsWithoutCheckbox,
-              dataVariables
+              variables: dataVariables
             })}
           </Table>
         )}


### PR DESCRIPTION
`<AutoTable>` was sending the wrong value for `variables` to its renderProps to render rows, and to its multiselect actions.

This PR passes through the proper `variables` (the exact same variables passed to the action) to the table row renderProps and multiselect actions. The upshot of which is refetching works as expected.