### PR TITLE
Autotable Refetch and Nested Formik Fields

### DIFF
--- a/src/ActionButton.jsx
+++ b/src/ActionButton.jsx
@@ -1,13 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
-import {
-  Button,
-  Icon,
-  IconButton,
-  Tooltip
-} from "@material-ui/core";
-import { withStyles } from '@material-ui/styles';
+import { Button, Icon, IconButton, Tooltip } from "@material-ui/core";
+import { withStyles } from "@material-ui/styles";
 
 const styles = theme => ({
   action: {
@@ -51,13 +46,14 @@ ActionButton.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   label: PropTypes.string.isRequired,
   link: PropTypes.string,
-  onClick: PropTypes.func.isRequired
+  onClick: PropTypes.func
 };
 
 ActionButton.defaultProps = {
   danger: null,
   icon: null,
-  link: null
+  link: null,
+  onClick: () => {}
 };
 
 const { classes, ...ActionButtonPropTypes } = ActionButton.propTypes;

--- a/src/AutoTable.jsx
+++ b/src/AutoTable.jsx
@@ -288,16 +288,17 @@ class AutoTable extends React.Component {
 
     const dataVariables = { ...variables, ordering, page, rowsPerPage, search };
 
-    const multiselectActionsWithState = multiselectActions.map(
-      ({ onClick, ...props }) => ({
+    const multiselectActionsWithState = ({ refetch }) =>
+      multiselectActions.map(({ onClick, ...props }) => ({
         ...props,
         onClick: () => {
           this.setState({ selectedItems: new Set() });
-          return onClick([...selectedItems], { variables: dataVariables });
+          return onClick([...selectedItems], {
+            variables: dataVariables,
+            refetch
+          });
         }
-      })
-    );
-
+      }));
     const columnsWithoutCheckbox = multiselectable
       ? tableColumns.slice(1)
       : tableColumns;
@@ -313,7 +314,7 @@ class AutoTable extends React.Component {
                 : tableColumns.map(({ sortId, ...column }) => column)
             }
             fullWidth={fullWidth}
-            multiselectActions={multiselectActionsWithState}
+            multiselectActions={multiselectActionsWithState(result)}
             onSearch={this.handleSearch}
             onSort={this.handleSort}
             padding={padding}

--- a/src/MaterialInput.jsx
+++ b/src/MaterialInput.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { TextField } from "@material-ui/core";
+import { getIn } from "formik";
 
 const MaterialInput = ({
   field,
@@ -12,8 +13,8 @@ const MaterialInput = ({
     {...props}
     {...field}
     value={field.value !== undefined ? field.value : ""}
-    error={Boolean(touched[field.name] && errors[field.name])}
-    label={(touched[field.name] && errors[field.name]) || label}
+    error={Boolean(getIn(touched, field.name) && getIn(errors, field.name))}
+    label={(getIn(touched, field.name) && getIn(errors, field.name)) || label}
   />
 );
 

--- a/src/MaterialInputSelect.jsx
+++ b/src/MaterialInputSelect.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Checkbox, MenuItem, TextField } from "@material-ui/core";
-import {getIn} from "formik";
+import { getIn } from "formik";
 
 // See https://github.com/mui-org/material-ui/issues/10938 for why haxx
 // If using in an MUI modal/dialog, be sure to pass `disableEnforceFocus=true`

--- a/src/MaterialInputSelect.jsx
+++ b/src/MaterialInputSelect.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Checkbox, MenuItem, TextField } from "@material-ui/core";
+import {getIn} from "formik";
 
 // See https://github.com/mui-org/material-ui/issues/10938 for why haxx
 // If using in an MUI modal/dialog, be sure to pass `disableEnforceFocus=true`
@@ -32,8 +33,8 @@ const MaterialInputSelect = ({
       value={
         field.value !== undefined ? field.value : defaultValue(multiSelect)
       }
-      error={Boolean(touched[field.name] && errors[field.name])}
-      label={(touched[field.name] && errors[field.name]) || label}
+      error={Boolean(getIn(touched, field.name) && getIn(errors, field.name))}
+      label={(getIn(touched, field.name) && getIn(errors, field.name)) || label}
       onBlur={event => {
         event.target.name = field.name; // eslint-disable-line
         handleBlur(event);


### PR DESCRIPTION
# Description


Exposed the `Data` component's `refetch` function to the `AutoTable`'s multiselect actions.

Fixed bug where nested fields weren't showing error message.


# 🏁 Ready to merge checklist

- [x] This branch is code-complete ( no outstanding requirements or TODOs )
- [x] I have tested this locally ( and it works )
- [x] All dependencies, migrations, etc are committed

# 📝 Notes / known issues
